### PR TITLE
rename to aicm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ yarn-error.log*
 # Temporary test directory
 tmp-test/
 
-# rules-manager
+# aicm
 .rules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📜 rules-manager
+# 📜 aicm
 
 A CLI tool for syncing AI IDE rules across projects
 
@@ -12,7 +12,7 @@ Development teams struggle with:
 
 As developers increasingly adopt AI-powered IDEs like Cursor and Windsurf, we have an opportunity to enforce best practices through "rules." However, these rules are typically isolated within individual developers or projects.
 
-**rules-manager** is a CLI tool that helps streamline rule management:
+**aicm** is a CLI tool that helps streamline AI configuration management:
 
 - 🏛️ **Single Source of Truth**: Define, maintain and version-control all AI IDE rules in one central repository
 - 📦 **Seamless Distribution**: Automatically synchronize the latest rules to developers' local projects using npm packages
@@ -53,7 +53,7 @@ In your project's `rules.json`, reference the package and the specific rule:
 ```json
 {
   "scripts": {
-    "postinstall": "npx -y rules-manager install"
+    "postinstall": "npx -y aicm install"
   }
 }
 ```
@@ -88,18 +88,18 @@ In your project's `rules.json`, reference the preset:
 }
 ```
 
-When you run `npx rules-manager install`, all rules from the preset will be installed to `.cursor/rules/`.
+When you run `npx aicm install`, all rules from the preset will be installed to `.cursor/rules/`.
 
 ### Demo
 
-Here is a package to demonstrate how rules manager works:
+Here is a package to demonstrate how aicm works:
 
 ```bash
 # Install a package containing a rule
 npm install --save-dev pirate-coding-rule
 
-# Install the rule via the rules-manager CLI
-npx -y rules-manager install pirate-coding pirate-coding-rule/rule.mdc
+# Install the rule via the aicm CLI
+npx -y aicm install pirate-coding pirate-coding-rule/rule.mdc
 ```
 
 This command will:
@@ -116,7 +116,7 @@ To prevent [prompt-injection](https://en.wikipedia.org/wiki/Prompt_injection), u
 
 ## Configuration
 
-rules-manager uses a JSON configuration file (`rules.json`) in your project root directory.
+aicm uses a JSON configuration file (`rules.json`) in your project root directory.
 
 ```json
 {
@@ -150,7 +150,7 @@ The type of rule is automatically detected based on the source format:
 Rules provided by NPM packages. The package must be installed either globally or in your project's `node_modules`. Sources that start with `@` or don't contain start with path separators are detected as NPM packages.
 
 ```json
-"react-best-practices": "@my-team/ai-tools/rules-manager-react"
+"react-best-practices": "@my-team/ai-tools/aicm-react"
 ```
 
 #### Local Source
@@ -180,7 +180,7 @@ These options are available for all commands:
 Initializes a new configuration file in your current directory.
 
 ```bash
-npx rules-manager init
+npx aicm init
 ```
 
 ### `install`
@@ -188,7 +188,7 @@ npx rules-manager init
 Installs rules from your configuration to the appropriate IDE locations.
 
 ```bash
-npx rules-manager install [rule-name] [rule-source]
+npx aicm install [rule-name] [rule-source]
 ```
 
 **Options:**
@@ -200,10 +200,10 @@ npx rules-manager install [rule-name] [rule-source]
 
 ```bash
 # Install all configured rules
-npx -y rules-manager install
+npx -y aicm install
 
 # Install a rule from an npm package and update configuration
-npx -y rules-manager install react-best-practices @my-team/ai-tools/react-best-practices.mdc
+npx -y aicm install react-best-practices @my-team/ai-tools/react-best-practices.mdc
 ```
 
 ## Contributing
@@ -226,7 +226,3 @@ npm run test:unit
 # Run only E2E tests
 npm run test:e2e
 ```
-
-## License
-
-MIT

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "rules-manager",
+  "name": "aicm",
   "version": "0.3.3",
   "description": "A TypeScript CLI tool for managing AI IDE rules across different projects and teams",
   "main": "dist/index.js",
   "bin": {
-    "rules-manager": "./dist/index.js"
+    "aicm": "./dist/index.js"
   },
   "files": [
     "dist",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -23,9 +23,7 @@ export function initCommand(): void {
     console.log(
       `  1. Edit ${chalk.blue("rules.json")} to configure your rules`,
     );
-    console.log(
-      `  2. Run ${chalk.blue("npx rules-manager install")} to install rules`,
-    );
+    console.log(`  2. Run ${chalk.blue("npx aicm install")} to install rules`);
   } catch (error) {
     console.error(chalk.red("Error creating configuration file:"), error);
   }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -100,7 +100,7 @@ export async function installCommand(): Promise<void> {
       console.log(
         `Edit your ${chalk.blue(
           "rules.json",
-        )} file to add rules or use the direct install command: npx rules-manager install <rule-name> <rule-source>`,
+        )} file to add rules or use the direct install command: npx aicm install <rule-name> <rule-source>`,
       );
       return;
     }
@@ -113,7 +113,7 @@ export async function installCommand(): Promise<void> {
         console.log(
           `Edit your ${chalk.blue(
             "rules.json",
-          )} file to add rules or use the direct install command: npx rules-manager install <rule-name> <rule-source>`,
+          )} file to add rules or use the direct install command: npx aicm install <rule-name> <rule-source>`,
         );
         return;
       }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -8,7 +8,7 @@ export function listCommand(): void {
 
   if (!config) {
     console.log(chalk.red("Configuration file not found!"));
-    console.log(`Run ${chalk.blue("npx rules-manager init")} to create one.`);
+    console.log(`Run ${chalk.blue("npx aicm init")} to create one.`);
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,13 +52,13 @@ switch (command) {
 
 function showHelp() {
   console.log(`
-${chalk.bold("rules-manager")} - A CLI tool for managing AI IDE rules
+${chalk.bold("aicm")} - A CLI tool for managing AI IDE configurations
 
 ${chalk.bold("USAGE")}
-  $ rules-manager [command] [options]
+  $ aicm [command] [options]
 
 ${chalk.bold("COMMANDS")}
-  init                Initialize a new rules-manager configuration file
+  init                Initialize a new aicm configuration file
   install             Install rules from configured sources
   list                List all configured rules and their status
 
@@ -67,8 +67,8 @@ ${chalk.bold("OPTIONS")}
   -v, --version       Show version number
 
 ${chalk.bold("EXAMPLES")}
-  $ rules-manager init
-  $ rules-manager install
-  $ rules-manager list
+  $ aicm init
+  $ aicm install
+  $ aicm list
 `);
 }

--- a/src/utils/windsurf-writer.ts
+++ b/src/utils/windsurf-writer.ts
@@ -1,8 +1,8 @@
 import fs from "fs-extra";
 import path from "path";
 
-const RULES_BEGIN = "<!-- RULES-MANAGER:BEGIN -->";
-const RULES_END = "<!-- RULES-MANAGER:END -->";
+const RULES_BEGIN = "<!-- AICM:BEGIN -->";
+const RULES_END = "<!-- AICM:END -->";
 const WARNING =
   "<!-- WARNING: Everything between these markers will be overwritten during installation -->";
 

--- a/tests/e2e/init.test.ts
+++ b/tests/e2e/init.test.ts
@@ -8,7 +8,7 @@ import fs from "fs-extra";
 import path from "path";
 import { testDir } from "./helpers";
 
-describe("rules-manager init command with fixtures", () => {
+describe("aicm init command with fixtures", () => {
   test("should create default config file", async () => {
     await setupFromFixture("init-empty", expect.getState().currentTestName);
 

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -6,7 +6,7 @@ import {
   readTestFile,
 } from "./helpers";
 
-describe("rules-manager install command with fixtures", () => {
+describe("aicm install command with fixtures", () => {
   test("should show error when no rule is specified", async () => {
     await setupFromFixture(
       "install-no-rules",

--- a/tests/e2e/list.test.ts
+++ b/tests/e2e/list.test.ts
@@ -1,6 +1,6 @@
 import { setupFromFixture, runCommand } from "./helpers";
 
-describe("rules-manager list command with fixtures", () => {
+describe("aicm list command with fixtures", () => {
   test("should list all rules in the config", async () => {
     await setupFromFixture(
       "list-with-multiple-rules",

--- a/tests/e2e/windsurf.test.ts
+++ b/tests/e2e/windsurf.test.ts
@@ -8,7 +8,7 @@ import {
   testDir,
 } from "./helpers";
 
-describe("rules-manager windsurf integration", () => {
+describe("aicm windsurf integration", () => {
   test("should install rules to .rules directory and update .windsurfrules", async () => {
     await setupFromFixture("windsurf-basic", expect.getState().currentTestName);
 
@@ -39,8 +39,8 @@ describe("rules-manager windsurf integration", () => {
     expect(fileExists(".windsurfrules")).toBe(true);
     const windsurfRulesContent = readTestFile(".windsurfrules");
 
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:BEGIN -->");
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:END -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:BEGIN -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:END -->");
 
     expect(windsurfRulesContent).toContain(
       "[*.ts] .rules/file-pattern-rule.md",
@@ -64,8 +64,8 @@ describe("rules-manager windsurf integration", () => {
     expect(windsurfRulesContent).toContain("<rules>");
     expect(windsurfRulesContent).toContain("</rules>");
 
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:BEGIN -->");
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:END -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:BEGIN -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:END -->");
     expect(windsurfRulesContent).toContain(".rules/new-rule.md");
   });
 
@@ -87,8 +87,8 @@ describe("rules-manager windsurf integration", () => {
     expect(fileExists(".windsurfrules")).toBe(true);
     const windsurfRulesContent = readTestFile(".windsurfrules");
 
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:BEGIN -->");
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:END -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:BEGIN -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:END -->");
     expect(windsurfRulesContent).toContain(".rules/single-rule.md");
   });
 
@@ -212,11 +212,11 @@ This rule is used to test appending markers to an existing file without markers.
     expect(windsurfRulesContent).toContain("# Existing Windsurf Rules");
     expect(windsurfRulesContent).toContain("These are some existing rules.");
 
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:BEGIN -->");
-    expect(windsurfRulesContent).toContain("<!-- RULES-MANAGER:END -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:BEGIN -->");
+    expect(windsurfRulesContent).toContain("<!-- AICM:END -->");
 
     const beginMarkerIndex = windsurfRulesContent.indexOf(
-      "<!-- RULES-MANAGER:BEGIN -->",
+      "<!-- AICM:BEGIN -->",
     );
     const existingContentIndex = windsurfRulesContent.indexOf(
       "# Existing Windsurf Rules",

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,6 +1,6 @@
 # Test Fixtures
 
-This directory contains all test fixtures for the rules-manager project, organized by test type.
+This directory contains all test fixtures for the aicm project, organized by test type.
 
 ## Directory Structure
 

--- a/tests/fixtures/list-with-no-rules/rules-manager.json
+++ b/tests/fixtures/list-with-no-rules/rules-manager.json
@@ -1,4 +1,0 @@
-{
-  "ides": ["cursor"],
-  "rules": {}
-}

--- a/tests/fixtures/windsurf-existing/.windsurfrules
+++ b/tests/fixtures/windsurf-existing/.windsurfrules
@@ -4,10 +4,10 @@ Manually written rules
 Some custom rules content here
 </rules>
 
-<!-- RULES-MANAGER:BEGIN -->
+<!-- AICM:BEGIN -->
 <!-- WARNING: Everything between these markers will be overwritten during installation -->
 
 The following rules apply to all files in the project:
 - .rules/existing-rule.md
 
-<!-- RULES-MANAGER:END -->
+<!-- AICM:END -->

--- a/tests/fixtures/windsurf-no-markers/rules-manager.json
+++ b/tests/fixtures/windsurf-no-markers/rules-manager.json
@@ -1,6 +1,0 @@
-{
-  "ides": ["windsurf"],
-  "rules": {
-    "no-marker-rule": "./rules/no-marker-rule.mdc"
-  }
-}


### PR DESCRIPTION
aicm stands for "ai configuration manager" or "agentic ide configuration manager".

While this project started as AI rules manager, I realized we could use the tool as a more generic configuration manager, adding mcp configuration and maybe more in the future.

This is a good time to do this before this gets many usages.